### PR TITLE
#1051 improve error handling

### DIFF
--- a/ios/Extensions/AnonCryptAlg+Extensions.swift
+++ b/ios/Extensions/AnonCryptAlg+Extensions.swift
@@ -1,7 +1,7 @@
 import DidcommSDK
 
 extension AnonCryptAlg {
-    static func fromString(_ type: String) -> AnonCryptAlg {
+    static func fromString(_ type: String) throws -> AnonCryptAlg {
         switch type {
         case "A256cbcHs512EcdhEsA256kw":
             return .a256cbcHs512EcdhEsA256kw
@@ -10,7 +10,7 @@ extension AnonCryptAlg {
         case "A256gcmEcdhEsA256kw":
             return .a256gcmEcdhEsA256kw
         default:
-            fatalError("AnonCryptAlg not supported! Supported types: 'A256cbcHs512EcdhEsA256kw', 'Xc20pEcdhEsA256kw' and 'A256gcmEcdhEsA256kw'.")
+            throw DecodeError.error("AnonCryptAlg not supported! Supported types: 'A256cbcHs512EcdhEsA256kw', 'Xc20pEcdhEsA256kw' and 'A256gcmEcdhEsA256kw'.")
         }
     }
 }

--- a/ios/Extensions/AnonCryptAlg+Extensions.swift
+++ b/ios/Extensions/AnonCryptAlg+Extensions.swift
@@ -1,7 +1,7 @@
 import DidcommSDK
 
 extension AnonCryptAlg {
-    static func fromString(_ type: String) -> AnonCryptAlg{
+    static func fromString(_ type: String) -> AnonCryptAlg {
         switch type {
         case "A256cbcHs512EcdhEsA256kw":
             return .a256cbcHs512EcdhEsA256kw

--- a/ios/Extensions/Attachment+Extensions.swift
+++ b/ios/Extensions/Attachment+Extensions.swift
@@ -1,13 +1,14 @@
 import DidcommSDK
 
 extension Attachment {
-    init(fromJson json: JSONDictionary) {
+    init(fromJson json: JSONDictionary) throws {
         
         guard let dataJson = json["data"] as? JSONDictionary else {
-            fatalError("Can't resolve 'data' from Attachment.")
+            throw DecodeError.error("Can't resolve 'data' from Attachment.")
         }
         
-        self.init(data: .fromJson(dataJson),
+        let attachmentData = try AttachmentData.fromJson(dataJson)
+        self.init(data: attachmentData,
                     id: json["id"] as? String,
                     description: json["description"] as? String,
                     filename: json["filename"] as? String,
@@ -30,7 +31,7 @@ extension Attachment {
 }
 
 extension AttachmentData {
-    static func fromJson(_ data: JSONDictionary) -> AttachmentData{
+    static func fromJson(_ data: JSONDictionary) throws -> AttachmentData {
         let jws = data["jws"] as? String
         if let base64 = data["base64"] as? String {
             return .base64(value: .init(base64: base64, jws: jws))
@@ -40,7 +41,7 @@ extension AttachmentData {
             let hash = data["hash"] as? String ?? ""
             return .links(value: .init(links: links, hash: hash, jws: jws))
         } else {
-            fatalError("AttachmentData not supported! Supported types: 'base64', 'json' and 'links'.")
+            throw DecodeError.error("AttachmentData not supported! Supported types: 'base64', 'json' and 'links'.")
         }
     }
     

--- a/ios/Extensions/DidDoc+Extensions.swift
+++ b/ios/Extensions/DidDoc+Extensions.swift
@@ -2,34 +2,34 @@ import DidcommSDK
 
 extension DidDoc {
     
-    init(fromJson json: JSONDictionary) {
+    init(fromJson json: JSONDictionary) throws {
         guard let did = json["did"] as? String else {
-            fatalError("Can't resolve 'did' from DidDoc.")
+            throw DecodeError.error("Can't resolve 'did' from DidDoc.")
         }
         
         guard let keyAgreements = json["key_agreements"] as? [String] else {
-            fatalError("Can't resolve 'key_agreements' from DidDoc.")
+            throw DecodeError.error("Can't resolve 'key_agreements' from DidDoc.")
         }
         
         guard let authentications = json["authentications"] as? [String] else {
-            fatalError("Can't resolve 'authentications' from DidDoc.")
+            throw DecodeError.error("Can't resolve 'authentications' from DidDoc.")
         }
         
         
         guard let verificationMethodsJson = json["verification_methods"] as? [JSONDictionary] else {
-            fatalError("Can't resolve 'verification_methods' from DidDoc.")
+            throw DecodeError.error("Can't resolve 'verification_methods' from DidDoc.")
         }
         
         guard let servicesJson = json["services"] as? [JSONDictionary] else {
-            fatalError("Can't resolve 'services' from DidDoc.")
+            throw DecodeError.error("Can't resolve 'services' from DidDoc.")
         }
         
-        let vMethods: [VerificationMethod] = verificationMethodsJson.map { verificationMethodJson in
-            return .init(fromJson: verificationMethodJson)
+        let vMethods: [VerificationMethod] = try verificationMethodsJson.map { verificationMethodJson in
+            return try VerificationMethod(fromJson: verificationMethodJson)
         }
         
-        let services: [Service] = servicesJson.map { serviceJson in
-            return .init(fromJson: serviceJson)
+        let services: [Service] = try servicesJson.map { serviceJson in
+            return try Service(fromJson: serviceJson)
         }
         
         self.init(did: did,
@@ -41,30 +41,30 @@ extension DidDoc {
 }
 
 extension VerificationMethod {
-    init(fromJson json: JSONDictionary) {
+    init(fromJson json: JSONDictionary) throws {
         
         guard let id = json["id"] as? String else {
-            fatalError("Can't resolve 'id' from VerificationMethod.")
+            throw DecodeError.error("Can't resolve 'id' from VerificationMethod.")
         }
 
         guard let type = json["type"] as? String else {
-            fatalError("Can't resolve 'type' from VerificationMethod.")
+            throw DecodeError.error("Can't resolve 'type' from VerificationMethod.")
         }
         
         guard let controller = json["controller"] as? String else {
-            fatalError("Can't resolve 'controller' from VerificationMethod.")
+            throw DecodeError.error("Can't resolve 'controller' from VerificationMethod.")
         }
         
         guard let verificationMaterialJson = json["verification_material"] as? JSONDictionary else {
-            fatalError("Can't resolve 'verification_material' from VerificationMethod.")
+            throw DecodeError.error("Can't resolve 'verification_material' from VerificationMethod.")
         }
         
         guard let format =  verificationMaterialJson["format"] as? String else {
-            fatalError("Can't resolve 'format' from Verification Material.")
+            throw DecodeError.error("Can't resolve 'format' from Verification Material.")
         }
         
         guard let value =  verificationMaterialJson["value"] as? JSONDictionary else {
-            fatalError("Can't resolve 'value' from Verification Material.")
+            throw DecodeError.error("Can't resolve 'value' from Verification Material.")
         }
         
         self.init(id: id,

--- a/ios/Extensions/FromPrior+Extensions.swift
+++ b/ios/Extensions/FromPrior+Extensions.swift
@@ -11,14 +11,14 @@ extension FromPrior {
                  "jti": jti ]
     }
     
-    init(fromJson fromPrior: NSDictionary) {
+    init(fromJson fromPrior: NSDictionary) throws {
         
         guard let iss = fromPrior.value(forKey: "iss") as? String  else {
-            fatalError("Can't resolve 'iss' from FromPrior.")
+            throw DecodeError.error("Can't resolve 'iss' from FromPrior.")
         }
         
         guard let sub = fromPrior.value(forKey: "sub") as? String else {
-            fatalError("Can't resolve 'sub' from FromPrior.")
+            throw DecodeError.error("Can't resolve 'sub' from FromPrior.")
         }
         
         self.init(iss: iss,

--- a/ios/Extensions/Message+Extensions.swift
+++ b/ios/Extensions/Message+Extensions.swift
@@ -22,29 +22,29 @@ extension Message {
                  "attachments": attachmentsJson ]
     }
     
-    init(fromJson json: NSDictionary) {
+    init(fromJson json: NSDictionary) throws {
     
         guard let id = json["id"] as? String else {
-            fatalError("Can't resolve 'id' from Message.")
+            throw DecodeError.error("Can't resolve 'id' from Message.")
         }
         
         guard let typ = json["typ"] as? String else {
-            fatalError("Can't resolve 'typ' from Message.")
+            throw DecodeError.error("Can't resolve 'typ' from Message.")
         }
         
         guard let type = json["type"] as? String else {
-            fatalError("Can't resolve 'type' from Message.")
+            throw DecodeError.error("Can't resolve 'type' from Message.")
         }
         
         guard let body = json["body"] as? JSONDictionary else {
-            fatalError("Can't resolve 'body' from Message.")
+            throw DecodeError.error("Can't resolve 'body' from Message.")
         }
        
         var attachments: [Attachment]?
         
         if let attachmentsJson = json["attachments"] as? [JSONDictionary] {
-            attachments = attachmentsJson.map { attachmentJson in
-                return .init(fromJson: attachmentJson)
+            attachments = try attachmentsJson.map { attachmentJson in
+                return try .init(fromJson: attachmentJson)
             }
         }
         

--- a/ios/Extensions/Secrets+Extensions.swift
+++ b/ios/Extensions/Secrets+Extensions.swift
@@ -2,26 +2,26 @@ import DidcommSDK
 
 import UIKit
 extension Secret {
-    init(fromJson json: JSONDictionary) {
+    init(fromJson json: JSONDictionary) throws {
         
         guard let id = json["id"] as? String else {
-            fatalError("Can't resolve 'id' from Secret.")
+            throw DecodeError.error("Can't resolve 'id' from Secret.")
         }
         
         guard let type = json["type"] as? String else {
-            fatalError("Can't resolve 'type' from Secret.")
+            throw DecodeError.error("Can't resolve 'type' from Secret.")
         }
         
         guard let secretMaterialJson = json["secret_material"] as? NSDictionary else {
-            fatalError("Can't resolve 'secret_material' from Secret Material.")
+            throw DecodeError.error("Can't resolve 'secret_material' from Secret Material.")
         }
         
         guard let format = secretMaterialJson.value(forKey: "format") as? String else {
-            fatalError("Can't resolve 'format' from Secret.")
+            throw DecodeError.error("Can't resolve 'format' from Secret.")
         }
         
         guard let value = secretMaterialJson.value(forKey: "value") as? JSONDictionary else {
-            fatalError("Can't resolve 'value' from Secret.")
+            throw DecodeError.error("Can't resolve 'value' from Secret.")
         }
         
         self.init(id: id, type: .fromString(type),

--- a/ios/Extensions/Service+Extensions.swift
+++ b/ios/Extensions/Service+Extensions.swift
@@ -1,14 +1,14 @@
 import DidcommSDK
 
 extension Service {
-    init(fromJson json: JSONDictionary) {
+    init(fromJson json: JSONDictionary) throws{
 
         guard let id = json["id"] as? String else {
-            fatalError("Can't resolve 'id' from Service.")
+            throw DecodeError.error("Can't resolve 'id' from Service.")
         }
 
         guard let serviceEndpoint = json["serviceEndpoint"] as? JSONDictionary else {
-            fatalError("Can't resolve 'serviceEndpoint' from Service.")
+            throw DecodeError.error("Can't resolve 'serviceEndpoint' from Service.")
         }
         
         self.init(id: id,

--- a/ios/Source/DIDCommFromPriorHelpersModule.swift
+++ b/ios/Source/DIDCommFromPriorHelpersModule.swift
@@ -16,18 +16,17 @@ class DIDCommFromPriorHelpersModule : NSObject {
         let (didResolver, secretsResolver) = createResolvers(with: resolversId)
         let delegate = DidPriorPromise(resolve, reject)
         
-        var message: FromPrior!
         do {
-            message = try FromPrior(fromJson: fromPriorData)
+            let message = try FromPrior(fromJson: fromPriorData)
+            let _ = DidComm(didResolver: didResolver, secretResolver: secretsResolver)
+                .packFromPrior(msg: message,
+                               issuerKid: issuerKid as String,
+                               cb: delegate)
         } catch {
             reject("Decode derror:", error.localizedDescription, error)
             return
         }
         
-        let _ = DidComm(didResolver: didResolver, secretResolver: secretsResolver)
-            .packFromPrior(msg: message,
-                           issuerKid: issuerKid as String,
-                           cb: delegate)
     }
     
     @objc(unpack:resolversId:withResolver:withRejecter:)
@@ -40,6 +39,7 @@ class DIDCommFromPriorHelpersModule : NSObject {
         
         let (didResolver, secretsResolver) = createResolvers(with: resolversId)
         let delegate = DidPriorPromise(resolve, reject)
+        
         let _ = DidComm(didResolver: didResolver,
                         secretResolver: secretsResolver)
             .unpackFromPrior(fromPriorJwt: fromPriorJwt.asString,

--- a/ios/Source/DIDCommFromPriorHelpersModule.swift
+++ b/ios/Source/DIDCommFromPriorHelpersModule.swift
@@ -16,8 +16,16 @@ class DIDCommFromPriorHelpersModule : NSObject {
         let (didResolver, secretsResolver) = createResolvers(with: resolversId)
         let delegate = DidPriorPromise(resolve, reject)
         
+        var message: FromPrior!
+        do {
+            message = try FromPrior(fromJson: fromPriorData)
+        } catch {
+            reject("Decode derror:", error.localizedDescription, error)
+            return
+        }
+        
         let _ = DidComm(didResolver: didResolver, secretResolver: secretsResolver)
-            .packFromPrior(msg: .init(fromJson: fromPriorData),
+            .packFromPrior(msg: message,
                            issuerKid: issuerKid as String,
                            cb: delegate)
     }

--- a/ios/Source/DIDCommFromPriorHelpersModule.swift
+++ b/ios/Source/DIDCommFromPriorHelpersModule.swift
@@ -22,8 +22,11 @@ class DIDCommFromPriorHelpersModule : NSObject {
                 .packFromPrior(msg: message,
                                issuerKid: issuerKid as String,
                                cb: delegate)
+        } catch DecodeError.error(let msg) {
+            reject("Decode derror:", msg, DecodeError.error(msg))
+            return
         } catch {
-            reject("Decode derror:", error.localizedDescription, error)
+            reject("Unknown error.", error.localizedDescription, error)
             return
         }
         

--- a/ios/Source/DIDCommMessageHelpersModule.swift
+++ b/ios/Source/DIDCommMessageHelpersModule.swift
@@ -36,8 +36,11 @@ class DIDCommMessageHelpersModule: NSObject {
                                signBy: signFrom?.asString,
                                options: options,
                                cb: delegate)
+        } catch DecodeError.error(let msg) {
+            reject("Decode derror:", msg, DecodeError.error(msg))
+            return
         } catch {
-            reject("Decode derror:", error.localizedDescription, error)
+            reject("Unknown error.", error.localizedDescription, error)
             return
         }
     }
@@ -60,8 +63,11 @@ class DIDCommMessageHelpersModule: NSObject {
                 .packSigned(msg: message,
                             signBy: signBy.asString,
                             cb: delegate)
+        } catch DecodeError.error(let msg) {
+            reject("Decode derror:", msg, DecodeError.error(msg))
+            return
         } catch {
-            reject("Decode derror:", error.localizedDescription, error)
+            reject("Unknown error.", error.localizedDescription, error)
             return
         }
     }
@@ -83,8 +89,11 @@ class DIDCommMessageHelpersModule: NSObject {
                             secretResolver: secretsResolver)
                 .packPlaintext(msg: message,
                                cb: delegate)
+        } catch DecodeError.error(let msg) {
+            reject("Decode derror:", msg, DecodeError.error(msg))
+            return
         } catch {
-            reject("Decode derror:", error.localizedDescription, error)
+            reject("Unknown error.", error.localizedDescription, error)
             return
         }
 
@@ -135,8 +144,11 @@ class DIDCommMessageHelpersModule: NSObject {
                                routingKeys: routingKeys as? [String] ?? [],
                                encAlgAnon: encAlgAnon,
                                cb: delegate)
+        } catch DecodeError.error(let msg) {
+            reject("Decode derror:", msg, DecodeError.error(msg))
+            return
         } catch {
-            reject("Decode derror:", error.localizedDescription, error)
+            reject("Unknown error.", error.localizedDescription, error)
             return
         }
     }

--- a/ios/Source/DIDCommMessageHelpersModule.swift
+++ b/ios/Source/DIDCommMessageHelpersModule.swift
@@ -15,6 +15,14 @@ class DIDCommMessageHelpersModule: NSObject {
                         reject: @escaping RCTPromiseRejectBlock) {
         
         print("[MessageHelpersModule] - Called packEncrypted")
+        
+        var message: Message!
+        do {
+            message = try Message(fromJson: messageData)
+        } catch {
+            reject("Decode derror:", error.localizedDescription, error)
+            return
+        }
 
         // This is the standard options for Encrypting.
         let options = PackEncryptedOptions(protectSender: protectSender,
@@ -27,7 +35,7 @@ class DIDCommMessageHelpersModule: NSObject {
         let (didResolver, secretsResolver) = createResolvers(with: resolversId)
         let delegate = DidPromise(resolve, reject)
         let _ = DidComm(didResolver: didResolver, secretResolver: secretsResolver)
-            .packEncrypted(msg: .init(fromJson: messageData),
+            .packEncrypted(msg: message,
                            to: to.asString,
                            from: from?.asString,
                            signBy: signFrom?.asString,
@@ -44,10 +52,18 @@ class DIDCommMessageHelpersModule: NSObject {
         
         print("[MessageHelpersModule] - Called packSigned")
         
+        var message: Message!
+        do {
+            message = try Message(fromJson: messageData)
+        } catch {
+            reject("Decode derror:", error.localizedDescription, error)
+            return
+        }
+        
         let (didResolver, secretsResolver) = createResolvers(with: resolversId)
         let delegate = DidPromise(resolve, reject)
         let _ = DidComm(didResolver: didResolver, secretResolver: secretsResolver)
-            .packSigned(msg: .init(fromJson: messageData),
+            .packSigned(msg: message,
                         signBy: signBy.asString,
                         cb: delegate)
     }
@@ -59,12 +75,20 @@ class DIDCommMessageHelpersModule: NSObject {
                          reject: @escaping RCTPromiseRejectBlock) {
         
         print("[MessageHelpersModule] - Called packPlaintext")
+        
+        var message: Message!
+        do {
+            message = try Message(fromJson: messageData)
+        } catch {
+            reject("Decode derror:", error.localizedDescription, error)
+            return
+        }
 
         let (didResolver, secretsResolver) = createResolvers(with: resolversId)
         let delegate = DidPromise(resolve, reject)
         let _ = DidComm(didResolver: didResolver,
                         secretResolver: secretsResolver)
-            .packPlaintext(msg: .init(fromJson: messageData),
+            .packPlaintext(msg: message,
                            cb: delegate)
     }
     

--- a/ios/Source/DidResolverProxy.swift
+++ b/ios/Source/DidResolverProxy.swift
@@ -26,7 +26,8 @@ public class DidResolverProxy: DidResolver {
                 queue: nil) { notification in
                     if let str = notification.object as? String,
                        let dic = str.asDictionary {
-                        completion(.init(fromJson: dic))
+                        let did = try? DidDoc(fromJson: dic)
+                        completion(did)
                     } else {
                         completion(nil)
                     }

--- a/ios/Source/SecretsResolverProxy.swift
+++ b/ios/Source/SecretsResolverProxy.swift
@@ -34,7 +34,8 @@ public class SecretsResolverProxy: SecretsResolver {
                 queue: nil) { notification in
                     if let str = notification.object as? String,
                        let dic = str.asDictionary {
-                        completion(Secret.init(fromJson: dic))
+                        let secret = try? Secret(fromJson: dic)
+                        completion(secret)
                     } else {
                         completion(nil)
                     }

--- a/ios/Source/Utils.swift
+++ b/ios/Source/Utils.swift
@@ -1,5 +1,10 @@
 import DidcommSDK
 
+
+enum DecodeError: Error {
+    case error(_ msg: String)
+}
+
 public func createResolvers(with resolversId: NSString) -> (DidResolverProxy, SecretsResolverProxy) {
     let didResolver = DidResolverProxy(resolversId: resolversId.asString)
     let secretsResolver = SecretsResolverProxy(resolversId:  resolversId.asString)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sicpa-dlab/didcomm-react-native",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "React Native wrapper for DIDComm v2",
   "main": "lib/module/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
- Called throw statement instead of fatal error
- Could not automatically decode & encode since the dictionary is not supported and it's necessary for `body` key.

Issue: https://github.com/sicpa-dlab/cbdc-projects/issues/1051