### PR TITLE
Take demo lock file into account

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,9 @@ jobs:
         with:
           node-version: "16"
           cache: "yarn"
-          cache-dependency-path: '{*/,}yarn.lock'
-
+          cache-dependency-path: |
+            **/yarn.lock
+            yarn.lock
       - name: install and link dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: "16"
           cache: "yarn"
-          cache-dependency-path: '**/yarn.lock'
+          cache-dependency-path: '{*/,}yarn.lock'
 
       - name: install and link dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           node-version: "16"
           cache: "yarn"
+          cache-dependency-path: '**/yarn.lock'
 
       - name: install and link dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
Currently, only the main `yarn.lock` file is taken into account when caching, which means that if the `demo/yarn.lock` file changes, the previously cached dependencies would still be used, which can make the build fail. See [setup-node action doc](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data) (under `Using wildcard patterns to cache dependencies`)